### PR TITLE
Fix boolean return types in SafeCurl::execute

### DIFF
--- a/src/SafeCurl.php
+++ b/src/SafeCurl.php
@@ -46,8 +46,9 @@ class SafeCurl {
      * Exectutes a cURL request, whilst checking that the URL abides by our whitelists/blacklists.
      *
      * @param string $url
+     * @return bool|string
      */
-    public function execute($url): string {
+    public function execute($url) {
         $redirected = false;
         $redirectCount = 0;
         $redirectLimit = $this->getFollowLocationLimit();


### PR DESCRIPTION
It's possible for `curl_exec` to return a boolean. The return type on `SafeCurl::execute` is currently too strict to allow this. That should now be resolved by removing the defined return type.